### PR TITLE
Badge image render

### DIFF
--- a/Develop/index.js
+++ b/Develop/index.js
@@ -76,7 +76,7 @@ const questions = [
 function writeToFile(data) {
     const readmeText = generateMarkdown(data);
     console.log(readmeText);
-    // fs.writeFile(`${data.fileName}.md`, readmeText, (err) => err ? console.error(err) : console.log(`${data.fileName}.md created!`));
+    fs.writeFile(`${data.fileName}.md`, readmeText, (err) => err ? console.error(err) : console.log(`${data.fileName}.md created!`));
 }
 
 // TODO: Create a function to initialize app

--- a/Develop/undefined.md
+++ b/Develop/undefined.md
@@ -1,0 +1,1 @@
+![License](https://img.shields.io/badge/License-MIT%20License-blue.svg)(https://opensource.org/licenses/MIT-License)

--- a/Develop/utils/generateMarkdown.js
+++ b/Develop/utils/generateMarkdown.js
@@ -7,9 +7,11 @@ function renderLicenseBadge(license, color) {
   if (license === "None") {
     return ""
   } else {
+    //Replaces space in license name with %20 to keep image link whole
+    var noSpaceLicense = license.split(" ").join("%20")
     //Gets rid of space in badge color list options (i.e. bright green becomes brightgreen)
-    var nospace = color.split(" ").join("")
-    return `[License](https://img.shields.io/badge/${license}-${nospace}.svg)`
+    var noSpaceColor = color.split(" ").join("")
+    return `![License](https://img.shields.io/badge/License-${noSpaceLicense}-${noSpaceColor}.svg)`
   }
 }
 
@@ -35,6 +37,8 @@ function renderLicenseSection(license) {
 
 // TODO: Create a function to generate markdown for README
 function generateMarkdown(data) {
+  return renderLicenseBadge(`${data.license}`, `${data.color}`)
+
   return `# ${data.title}
   
   ## Description
@@ -65,7 +69,11 @@ function generateMarkdown(data) {
   ## License
 
   `
-    + renderLicenseBadge(`${data.license}`, `${data.color}`) +
+    +
+
+    renderLicenseBadge(`${data.license}`, `${data.color}`)
+
+    +
 
     `
 


### PR DESCRIPTION
This update changes the returned value of renderLicenseBadge so that the license badge image made renders properly. To do this, the returned value has an exclamation point, in the beginning, to denote that this is an image. 

In addition, the license text chosen will now transform into a single value with %20 code to replace the spaces, so that the rendered image displays blank spaces correctly onto the badge image.

Finally, "License-" was added to the endpoint to label the badge type.