### PR TITLE
License badge with link

### DIFF
--- a/Develop/index.js
+++ b/Develop/index.js
@@ -10,11 +10,11 @@ const questions = [
     //     message: "What is the name of your file?",
     //     name: "fileName",
     // },
-    {
-        type: "input",
-        message: "What is the name of your project?",
-        name: "title",
-    },
+    // {
+    //     type: "input",
+    //     message: "What is the name of your project?",
+    //     name: "title",
+    // },
     // {
     //     type: "input",
     //     message: "How would you describe your project",
@@ -43,22 +43,24 @@ const questions = [
     {
         type: "list",
         message: "Which license does your project have?",
-        choices: ["GNU AGPLv3", "GNU GPLv3", "GNU LGPLv3",
-            "Mozilla Public License 2.0", "Apache License 2.0",
-            "MIT License", "Boost Software License 1.0", "The Unlicense",
-            "CC0-1.0", "CC-BY-4.0", "CC-BY-SA-4.0", "SIL Open Font License 1.1",
-            "CERN-OHL-P-2.0", "CERN-OHL-W-2.0", "CERN-OHL-S-2.0", "Other", "None"],
+        choices: ["GNU AGPLv3 [agpl-3.0]", "GNU GPLv3 [gpl-3.0]",
+            "GNU LGPLv3 [lgpl-3.0]", "Mozilla Public License 2.0 [mpl-2.0]",
+            "Apache License 2.0 [apache-2.0]", "MIT License [mit]",
+            "Boost Software License 1.0 [bsl-1.0]", "The Unlicense [unlicense]",
+            "CC0-1.0 [cc0-1.0]", "CC-BY-4.0 [cc-by-4.0]", "CC-BY-SA-4.0 [cc-by-sa-4.0]",
+            "SIL Open Font License 1.1 [ofl-1.1]", "CERN-OHL-P-2.0 [cern-ohl-p-2.0]",
+            "CERN-OHL-W-2.0 [cern-ohl-w-2.0]", "CERN-OHL-S-2.0 [cern-ohl-s-2.0]", "None"],
         name: "license",
     },
-    {
-        type: "list",
-        message: "What color would you like your license badge to be?",
-        choices: ["bright green", "green", "yellow green",
-            "yellow", "red", "blue", "light grey",
-            "success", "important", "critical", "informative", "inactive",
-            "blue violet", "ff69b4", "9cf"],
-        name: "color",
-    },
+    // {
+    //     type: "list",
+    //     message: "What color would you like your license badge to be?",
+    //     choices: ["bright green", "green", "yellow green",
+    //         "yellow", "red", "blue", "light grey",
+    //         "success", "important", "critical", "informative", "inactive",
+    //         "blue violet", "ff69b4", "9cf"],
+    //     name: "color",
+    // },
     // {
     //     type: "input",
     //     message: "What is your GitHub username?",
@@ -76,7 +78,7 @@ const questions = [
 function writeToFile(data) {
     const readmeText = generateMarkdown(data);
     console.log(readmeText);
-    fs.writeFile(`${data.fileName}.md`, readmeText, (err) => err ? console.error(err) : console.log(`${data.fileName}.md created!`));
+    fs.writeFile(`test.md`, readmeText, (err) => err ? console.error(err) : console.log(`${data.fileName}.md created!`));
 }
 
 // TODO: Create a function to initialize app

--- a/Develop/test.md
+++ b/Develop/test.md
@@ -1,0 +1,1 @@
+[![License](https://img.shields.io/badge/License-CERN--OHL--S--2.0-undefined.svg)](https://choosealicense.com/licenses/cern-ohl-s-2.0)

--- a/Develop/undefined.md
+++ b/Develop/undefined.md
@@ -1,1 +1,0 @@
-![License](https://img.shields.io/badge/License-MIT%20License-blue.svg)(https://opensource.org/licenses/MIT-License)

--- a/Develop/utils/generateMarkdown.js
+++ b/Develop/utils/generateMarkdown.js
@@ -7,21 +7,36 @@ function renderLicenseBadge(license, color) {
   if (license === "None") {
     return ""
   } else {
-    //Replaces space in license name with %20 to keep image link whole
-    var noSpaceLicense = license.split(" ").join("%20")
+    // Splits the license option in between name and url code in brackets, []
+    var noSpaceLicense = license.split(" [")
+    console.log(noSpaceLicense)
+    // Stores license name into licenseName variable
+    var licenseName = noSpaceLicense[0]
+    //Replaces space in license name with %20 OR hyphen with double hyphens to keep image link whole yet display with space/hyphen in badge
+    if (licenseName.includes("-")) {
+      console.log("has hyphen")
+      var renderLicense = licenseName.split("-").join("--")
+    } else {
+      console.log("has space")
+      var renderLicense = licenseName.split(" ").join("%20")
+    }
     //Gets rid of space in badge color list options (i.e. bright green becomes brightgreen)
-    var noSpaceColor = color.split(" ").join("")
-    return `![License](https://img.shields.io/badge/License-${noSpaceLicense}-${noSpaceColor}.svg)`
+    var colorName = color.split(" ").join("")
+    return `[![License](https://img.shields.io/badge/License-${renderLicense}-${colorName}.svg)]`
   }
 }
 
 // TODO: Create a function that returns the license link
 // If there is no license, return an empty string
 function renderLicenseLink(license) {
-  if (license === none) {
+  if (license === "None") {
     return "";
   } else {
-
+    // Splits the license option in between name and url code in brackets, []
+    var licenseSplit1 = license.split(" [")
+    // Splits license code from closing square bracket and stores license name into licenseLinkCode variable
+    var licenseLinkCode = licenseSplit1[1].split("]").join("")
+    return `(https://choosealicense.com/licenses/${licenseLinkCode})`
   }
 }
 
@@ -31,13 +46,13 @@ function renderLicenseSection(license) {
   if (license === none) {
     return "";
   } else {
-
+    
   }
 }
 
 // TODO: Create a function to generate markdown for README
 function generateMarkdown(data) {
-  return renderLicenseBadge(`${data.license}`, `${data.color}`)
+  return renderLicenseBadge(`${data.license}`, `${data.color}`) + renderLicenseLink(`${data.license}`)
 
   return `# ${data.title}
   

--- a/README.md
+++ b/README.md
@@ -3,19 +3,25 @@
 [How to create a Professional README](https://coding-boot-camp.github.io/full-stack/github/professional-readme-guide)
 
 GIVEN a command-line application that accepts user input
-WHEN I am prompted for information about my application repository
-THEN a high-quality, professional README.md is generated with the title of my project and sections entitled Description, Table of Contents, Installation, Usage, License, Contributing, Tests, and Questions
+WHEN I am prompted for information about my application repository 
+THEN a high-quality, professional README.md is generated with the title of my project and sections entitled Description, Table of Contents, Installation, Usage, License, Contributing, Tests, and Questions<!--complete-->
 WHEN I enter my project title
-THEN this is displayed as the title of the README
+THEN this is displayed as the title of the README<!--complete-->
 WHEN I enter a description, installation instructions, usage information, contribution guidelines, and test instructions
-THEN this information is added to the sections of the README entitled Description, Installation, Usage, Contributing, and Tests
+THEN this information is added to the sections of the README entitled Description, Installation, Usage, Contributing, and Tests<!--complete-->
 WHEN I choose a license for my application from a list of options
-THEN a badge for that license is added near the top of the README and a notice is added to the section of the README entitled License that explains which license the application is covered under
-WHEN I enter my GitHub username
-THEN this is added to the section of the README entitled Questions, with a link to my GitHub profile
+THEN a badge for that license is added near the top of the README and a notice is added to the section of the README entitled License that explains which license the application is covered under<!--TODO!!!!!!!!!!!!!!!!!-->
+WHEN I enter my GitHub username<!--complete-->
+THEN this is added to the section of the README entitled Questions, with a link to my GitHub profile<!--complete-->
 WHEN I enter my email address
-THEN this is added to the section of the README entitled Questions, with instructions on how to reach me with additional questions
+THEN this is added to the section of the README entitled Questions, with instructions on how to reach me with additional questions<!--complete-->
 WHEN I click on the links in the Table of Contents
-THEN I am taken to the corresponding section of the README
+THEN I am taken to the corresponding section of the README<!--complete-->
 
 license information provided by [Choose a License](https://choosealicense.com/)
+
+mailto in markdown file information: https://agea.github.io/tutorial.md/
+
+table of contents link to titles with spaces credit to [Guillaume](https://community.atlassian.com/t5/user/viewprofilepage/user-id/1164328): https://community.atlassian.com/t5/Bitbucket-questions/How-to-write-a-table-of-contents-in-a-Readme-md/qaq-p/673363
+
+Using include() method to check if string has a certain character: https://careerkarma.com/blog/javascript-string-contains/#:~:text=You%20can%20check%20if%20a,designed%20specifically%20for%20that%20purpose


### PR DESCRIPTION
This update changes the badge options to include the URL code needed to form the hyperlinks by adding brackets and the respective license's choosealicense.com URL text.

The renderLicense variable has been changed to include license's whose names are not separate by space but by joined by hyphens, requiring a different URL pattern format to include double hyphens in the URL rather than 1 hyphen, so that the badge continues to display the hyphen in the name. Also, noSpaceColor has been renamed to colorName.

Finally, the renderLicenseLink function is now operational by splitting the option's text to isolate the URL code and placing it into the Choose A License URL.