### PR TITLE
Render license section

### DIFF
--- a/Develop/index.js
+++ b/Develop/index.js
@@ -78,7 +78,7 @@ const questions = [
 function writeToFile(data) {
     const readmeText = generateMarkdown(data);
     console.log(readmeText);
-    fs.writeFile(`test.md`, readmeText, (err) => err ? console.error(err) : console.log(`${data.fileName}.md created!`));
+    fs.writeFile(`${data.fileName}.md`, readmeText, (err) => err ? console.error(err) : console.log(`${data.fileName}.md created!`));
 }
 
 // TODO: Create a function to initialize app

--- a/Develop/undefined.md
+++ b/Develop/undefined.md
@@ -1,1 +1,3 @@
+## License
+
 This application is covered under The Unlicense license.

--- a/Develop/utils/generateMarkdown.js
+++ b/Develop/utils/generateMarkdown.js
@@ -9,7 +9,6 @@ function renderLicenseBadge(license, color) {
   } else {
     // Splits the license option in between name and url code in brackets, []
     var noSpaceLicense = license.split(" [")
-    console.log(noSpaceLicense)
     // Stores license name into licenseName variable
     var licenseName = noSpaceLicense[0]
     //Replaces space in license name with %20 OR hyphen with double hyphens to keep image link whole yet display with space/hyphen in badge
@@ -43,15 +42,26 @@ function renderLicenseLink(license) {
 // TODO: Create a function that returns the license section of README
 // If there is no license, return an empty string
 function renderLicenseSection(license) {
-  if (license === none) {
+  if (license === "None") {
     return "";
+  } else if (license.includes("The")) {
+    // Splits the license option in between name and url code in brackets, []
+    var noSpaceLicense = license.split(" [")
+    // Stores license name into licenseName variable
+    var licenseName = noSpaceLicense[0]
+    //If the license doesn't have the word "The" in it already, does not have the word 'the' preceding the license name
+    return `## License\n\nThis application is covered under ${licenseName} license.`
   } else {
-    
+    var noSpaceLicense = license.split(" [")
+    var licenseName = noSpaceLicense[0]
+    //If the license doesn't have the word "The" in it already, has the word 'the' preceding the license name
+    return `## License\n\nThis application is covered under the ${licenseName} license.`
   }
 }
 
 // TODO: Create a function to generate markdown for README
 function generateMarkdown(data) {
+  return renderLicenseSection(`${data.license}`)
   return renderLicenseBadge(`${data.license}`, `${data.color}`) + renderLicenseLink(`${data.license}`)
 
   return `# ${data.title}

--- a/README.md
+++ b/README.md
@@ -25,3 +25,5 @@ mailto in markdown file information: https://agea.github.io/tutorial.md/
 table of contents link to titles with spaces credit to [Guillaume](https://community.atlassian.com/t5/user/viewprofilepage/user-id/1164328): https://community.atlassian.com/t5/Bitbucket-questions/How-to-write-a-table-of-contents-in-a-Readme-md/qaq-p/673363
 
 Using include() method to check if string has a certain character: https://careerkarma.com/blog/javascript-string-contains/#:~:text=You%20can%20check%20if%20a,designed%20specifically%20for%20that%20purpose
+
+Using \n to make a new line JS to generate new lines in the markup file: https://www.simplilearn.com/tutorials/javascript-tutorial/javascript-new-line#:~:text=The%20newline%20character%20is%20%5Cn,new%20line%20to%20a%20string.


### PR DESCRIPTION
This update adds functionality to the renderLicenseSection function. The license section will generate, including the header, with the following text: "This application is covered under (the) [license name] license", with the word 'the' being omitted if the license name includes the word already.